### PR TITLE
Update Drush to v7.0.0 (latest stable)

### DIFF
--- a/manifests/composer.pp
+++ b/manifests/composer.pp
@@ -1,4 +1,6 @@
-class forumone::composer() {
+class forumone::composer(
+  $home = '/home/vagrant/.composer'
+) {
   # Download and install composer in one command 
   exec { 'forumone::composer::install':
     command => "curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer",

--- a/manifests/composer.pp
+++ b/manifests/composer.pp
@@ -1,0 +1,10 @@
+class forumone::composer() {
+  # Download and install composer in one command 
+  exec { 'forumone::composer::install':
+    command => "curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer",
+    path    => '/usr/bin',
+    creates => "/usr/bin/composer",
+    timeout => 4800,
+    require => Package["${::forumone::php::prefix}-fpm"]
+  }
+}

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -6,6 +6,7 @@ class forumone::drush ($version = '7.0.0') {
   # Download drush
   exec { 'forumone::drush::download':
     command => "wget --directory-prefix=/opt -O {$filename} https://github.com/drush-ops/drush/archive/${filename}",
+    cwd     => '/opt',
     path    => '/usr/bin',
     creates => "/opt/${filename}",
     timeout => 4800,

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -45,5 +45,6 @@ class forumone::drush ($version = '7.0.0') {
     path    => ['/usr/bin', '/user/local/bin'],
     creates => "/opt/drush-${version}/vendor/bin/phpunit",
     require => [Exec["forumone::drush::extract"], Class['forumone::composer']]
+    environment => ["COMPOSER_HOME=${::forumone::composer::home}"]
   }
 }

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -42,6 +42,6 @@ class forumone::drush ($version = '7.0.0') {
     command => "composer install",
     path => '/opt/drush-{$version}',
     creates => '/opt/drush-{$version}/vendor/bin/phpunit',
-    require => [Exec["forumone::drush::extract"], Exec['forumone::composer']]
+    require => [Exec["forumone::drush::extract"], Class['forumone::composer']]
   }
 }

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -5,7 +5,7 @@ class forumone::drush ($version = '7.0.0') {
   
   # Download drush
   exec { 'forumone::drush::download':
-    command => "wget --directory-prefix=/opt -O {$filename} https://github.com/drush-ops/drush/archive/${filename}",
+    command => "wget --directory-prefix=/opt -O ${filename} https://github.com/drush-ops/drush/archive/${filename}",
     cwd     => '/opt',
     path    => '/usr/bin',
     creates => "/opt/${filename}",

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -1,5 +1,7 @@
 class forumone::drush ($version = '7.0.0') {
   $filename = "${version}.zip"
+  class { "forumone::composer": }
+
 
   # Download drush
   exec { 'forumone::drush::download':
@@ -7,7 +9,6 @@ class forumone::drush ($version = '7.0.0') {
     path    => '/usr/bin',
     creates => "/opt/${filename}",
     timeout => 4800,
-    require => Exec["forumone::composer::install"],
   }
 
   # extract from the archive
@@ -40,6 +41,6 @@ class forumone::drush ($version = '7.0.0') {
     command => "composer install",
     path => '/opt/drush-{$version}',
     creates => '/opt/drush-{$version}/vendor/bin/phpunit',
-    require => Exec["forumone::drush::extract"],
+    require => [Exec["forumone::drush::extract"], Exec['forumone::composer']]
   }
 }

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -30,7 +30,7 @@ class forumone::drush ($version = '7.0.0') {
   file { "/opt/drush-${version}/lib":
     ensure  => directory,
     owner   => 'vagrant',
-    require => File['/opt/drush-${version}']
+    require => File["/opt/drush-${version}"]
   }
 
   file { '/usr/local/bin/drush':

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -1,7 +1,7 @@
 class forumone::drush ($version = '7.0.0') {
   $filename = "${version}.zip"
 
-  class { 'forumone::composer': }
+  include forumone::composer
   
   # Download drush
   exec { 'forumone::drush::download':

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -15,7 +15,7 @@ class forumone::drush ($version = '7.0.0') {
   # extract from the archive
   exec { 'forumone::drush::extract':
     command => "unzip /opt/${filename} -d /opt",
-    path    => ["/bin", "usr/bin"],
+    path    => ["/bin", "/usr/bin"],
     require => Exec["forumone::drush::download"],
     creates => '/opt/drush-{$version}/LICENSE.txt',
   }

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -15,7 +15,7 @@ class forumone::drush ($version = '7.0.0') {
   # extract from the archive
   exec { 'forumone::drush::extract':
     command => "unzip /opt/${filename} -d /opt",
-    path    => ["/bin"],
+    path    => ["/bin", "usr/bin"],
     require => Exec["forumone::drush::download"],
     creates => '/opt/drush-{$version}/LICENSE.txt',
   }

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -44,7 +44,7 @@ class forumone::drush ($version = '7.0.0') {
     cwd     => "/opt/drush-${version}",
     path    => ['/usr/bin', '/user/local/bin'],
     creates => "/opt/drush-${version}/vendor/bin/phpunit",
-    require => [Exec["forumone::drush::extract"], Class['forumone::composer']]
+    require => [Exec["forumone::drush::extract"], Class['forumone::composer']],
     environment => ["COMPOSER_HOME=${::forumone::composer::home}"]
   }
 }

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -1,15 +1,13 @@
 class forumone::drush ($version = '7.0.0') {
   $filename = "${version}.zip"
 
-  include forumone::composer
-  
   # Download drush
   exec { 'forumone::drush::download':
     command => "wget --directory-prefix=/opt -O {$filename} https://github.com/drush-ops/drush/archive/${filename}",
     path    => '/usr/bin',
     creates => "/opt/${filename}",
     timeout => 4800,
-    require => Exec["forumone::composer::install"],
+    require => Class['forumone::composer'],
   }
 
   # extract from the archive

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -1,6 +1,8 @@
 class forumone::drush ($version = '7.0.0') {
   $filename = "${version}.zip"
 
+  include forumone::composer
+  
   # Download drush
   exec { 'forumone::drush::download':
     command => "wget --directory-prefix=/opt -O {$filename} https://github.com/drush-ops/drush/archive/${filename}",

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -41,7 +41,7 @@ class forumone::drush ($version = '7.0.0') {
 
   exec {'forumone::drush::composer':
     command => "composer install",
-    path => "/opt/drush-${version}",
+    path => ['/usr/bin', '/user/local/bin'],
     creates => "/opt/drush-${version}/vendor/bin/phpunit",
     require => [Exec["forumone::drush::extract"], Class['forumone::composer']]
   }

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -21,13 +21,13 @@ class forumone::drush ($version = '7.0.0') {
     creates => '/opt/drush-${version}/README.md',
   }
 
-  file { '/opt/drush-${version}':
+  file { "/opt/drush-${version}":
     ensure  => directory,
     owner   => 'vagrant',
     require => Exec['forumone::drush::extract']
   }
 
-  file { '/opt/drush-${version}/lib':
+  file { "/opt/drush-${version}/lib":
     ensure  => directory,
     owner   => 'vagrant',
     require => File['/opt/drush-${version}']
@@ -35,14 +35,14 @@ class forumone::drush ($version = '7.0.0') {
 
   file { '/usr/local/bin/drush':
     ensure  => 'link',
-    target  => '/opt/drush-${version}/drush',
+    target  => "/opt/drush-${version}/drush",
     require => Exec['forumone::drush::extract']
   }
 
   exec {'forumone::drush::composer':
     command => "composer install",
-    path => '/opt/drush-${version}',
-    creates => '/opt/drush-${version}/vendor/bin/phpunit',
+    path => "/opt/drush-${version}",
+    creates => "/opt/drush-${version}/vendor/bin/phpunit",
     require => [Exec["forumone::drush::extract"], Class['forumone::composer']]
   }
 }

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -2,7 +2,7 @@ class forumone::drush ($version = '7.0.0') {
   $filename = "${version}.zip"
 
   include forumone::composer
-  
+
   # Download drush
   exec { 'forumone::drush::download':
     command => "wget --directory-prefix=/opt -O ${filename} https://github.com/drush-ops/drush/archive/${filename}",
@@ -39,9 +39,10 @@ class forumone::drush ($version = '7.0.0') {
     require => Exec['forumone::drush::extract']
   }
 
-  exec {'forumone::drush::composer':
+  exec { 'forumone::drush::composer':
     command => "composer install",
-    path => ['/usr/bin', '/user/local/bin'],
+    cwd     => "/opt/drush-${version}",
+    path    => ['/usr/bin', '/user/local/bin'],
     creates => "/opt/drush-${version}/vendor/bin/phpunit",
     require => [Exec["forumone::drush::extract"], Class['forumone::composer']]
   }

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -18,31 +18,31 @@ class forumone::drush ($version = '7.0.0') {
     command => "unzip /opt/${filename} -d /opt",
     path    => ["/bin", "/usr/bin"],
     require => Exec["forumone::drush::download"],
-    creates => '/opt/drush-{$version}/LICENSE.txt',
+    creates => '/opt/drush-${version}/LICENSE.txt',
   }
 
-  file { '/opt/drush-{$version}':
+  file { '/opt/drush-${version}':
     ensure  => directory,
     owner   => 'vagrant',
     require => Exec['forumone::drush::extract']
   }
 
-  file { '/opt/drush-{$version}/lib':
+  file { '/opt/drush-${version}/lib':
     ensure  => directory,
     owner   => 'vagrant',
-    require => File['/opt/drush-{$version}']
+    require => File['/opt/drush-${version}']
   }
 
   file { '/usr/local/bin/drush':
     ensure  => 'link',
-    target  => '/opt/drush-{$version}/drush',
+    target  => '/opt/drush-${version}/drush',
     require => Exec['forumone::drush::extract']
   }
 
   exec {'forumone::drush::composer':
     command => "composer install",
-    path => '/opt/drush-{$version}',
-    creates => '/opt/drush-{$version}/vendor/bin/phpunit',
+    path => '/opt/drush-${version}',
+    creates => '/opt/drush-${version}/vendor/bin/phpunit',
     require => [Exec["forumone::drush::extract"], Class['forumone::composer']]
   }
 }

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -1,6 +1,8 @@
 class forumone::drush ($version = '7.0.0') {
   $filename = "${version}.zip"
 
+  class { 'forumone::composer': }
+  
   # Download drush
   exec { 'forumone::drush::download':
     command => "wget --directory-prefix=/opt -O {$filename} https://github.com/drush-ops/drush/archive/${filename}",

--- a/manifests/drush.pp
+++ b/manifests/drush.pp
@@ -15,10 +15,10 @@ class forumone::drush ($version = '7.0.0') {
 
   # extract from the archive
   exec { 'forumone::drush::extract':
-    command => "unzip /opt/${filename} -d /opt",
+    command => "unzip -o /opt/${filename} -d /opt",
     path    => ["/bin", "/usr/bin"],
     require => Exec["forumone::drush::download"],
-    creates => '/opt/drush-${version}/LICENSE.txt',
+    creates => '/opt/drush-${version}/README.md',
   }
 
   file { '/opt/drush-${version}':


### PR DESCRIPTION
Drush 5.9 is out of date and a pain in the butt. Update to Drush 7.0.0 . This means:
- install Composer
- download Drush from github instead of drupal.org
- "composer install" to get dependencies
- drush's composer dependencies need the php-process package installed.

We've got composer and drush, but php-process still needs to be added.
