### PR TITLE
Allow one-off package installation

### DIFF
--- a/manifests/yum_extra.pp
+++ b/manifests/yum_extra.pp
@@ -1,0 +1,4 @@
+class forumone::yum_extra ($modules = []) {
+    package { $modules:
+    }
+}


### PR DESCRIPTION
Some projects need to install some extra packages (like `libfoo-devel` as an npm dependency).

This PR creates a `yum_extra` class that users can opt in to:

``` yaml
classes:
  - forumone::yum_extra

forumone::yum_extra::modules:
  - whatever
```
