### PR TITLE
Fix typo in ffprobe class

### DIFF
--- a/manifests/ffprobe.pp
+++ b/manifests/ffprobe.pp
@@ -7,7 +7,7 @@ class forumone::ffprobe () {
     exec { "forumone::ffprobe::download":
         command => "wget --directory-prefix=/tmp ${url}",
         path => "/usr/bin",
-        creates => "/tmp/${flename}",
+        creates => "/tmp/${filename}",
         timeout => 4800,
     }
 


### PR DESCRIPTION
Not sure how this didn't get caught by my testing, but it turns out that I typo'ed `${filename}` in the download exec declaration.
