### PR TITLE
Install ca-certificates package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,10 @@ class forumone ($ports = [80, 443, 8080, 8081, 18983, 8983, 3306, 13306, 1080, 4
     content => template("forumone/bashrc.erb"),
   }
 
+  package { "ca-certificates":
+    ensure => latest,
+  }
+
   create_resources('forumone::solr::collection', hiera_hash('forumone::solr::collections', {
   }
   ))


### PR DESCRIPTION
Drush and composer are having trouble downloading packages from their repositories. Without ca-certificates, wget can't access HTTPS endpoints. This change unconditionally installs the package to make sure it's always available.